### PR TITLE
Add extra data fetching to notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ Dieses Projekt untersucht die Vorhersage positiver und negativer Ausgleichsenerg
 ## Inhalt des Repositories
 
 - `LEITFADEN_AUSGLEICHSENERGIE.md` – Ausführliche Erläuterung der Datenquellen, möglicher Features und Modellierungsansätze.
-- `ausgleichsenergiepreisprognose.ipynb` – Notebook mit einem ersten Demonstrationscode zum Datenbezug und einem einfachen Basismodell.
-- `fetch_additional_data.py` – Beispielskript zum Abruf weiterer Datenquellen (ENTSO-E, Wetter, Feiertage).
+- `ausgleichsenergiepreisprognose.ipynb` – Notebook mit einem ersten Demonstrationscode zum Datenbezug, einem einfachen Basismodell und integrierten Funktionen für zusätzliche Datenquellen.
+- `fetch_additional_data.py` – Beispielskript zum Abruf weiterer Datenquellen (ENTSO-E, Wetter, Feiertage), die nun auch im Notebook verfügbar sind.
 
 ## Nutzung
 
 1. Klonen oder herunterladen des Repositories.
 2. Das Notebook `ausgleichsenergiepreisprognose.ipynb` in einer lokalen Jupyter-Umgebung öffnen.
 3. Die einzelnen Zellen nacheinander ausführen. Bei fehlender Internetverbindung werden Platzhalterdaten erzeugt.
-4. Optional kann `fetch_additional_data.py` ausgeführt werden, um weitere Daten zu laden und eine zusammengeführte CSV-Datei zu erzeugen.
+4. Optional kann `fetch_additional_data.py` separat ausgeführt werden, um dieselben Datenquellen abzurufen und eine zusammengeführte CSV-Datei zu erzeugen.
 
 Weitere Hinweise zu Datenquellen und Vorgehensweise finden sich im Leitfaden.
 

--- a/ausgleichsenergiepreisprognose.ipynb
+++ b/ausgleichsenergiepreisprognose.ipynb
@@ -83,6 +83,25 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": "### Zus\u00e4tzliche Datenquellen\nUm weitere Kontextinformationen einzubeziehen, k\u00f6nnen ENTSO-E Lastdaten, Wetterdaten und Schweizer Feiertage geladen werden. Bei fehlenden Bibliotheken oder Token werden Dummy-Daten erzeugt."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "\nfrom datetime import datetime, timedelta\nimport os\n\ntry:\n    from entsoe import EntsoePandasClient\nexcept ImportError:\n    EntsoePandasClient = None\n\ntry:\n    import holidays\nexcept ImportError:\n    holidays = None\n\n# ENTSO-E load data\n\ndef fetch_entsoe_load(start: datetime, end: datetime, token: str) -> pd.DataFrame:\n    if EntsoePandasClient is None:\n        raise RuntimeError('entsoe-py not installed')\n    client = EntsoePandasClient(api_key=token)\n    try:\n        load = client.query_load(country_code='CH', start=start, end=end)\n        load = load.rename('load')\n        return load.to_frame()\n    except Exception as e:\n        print(f'Could not download ENTSO-E data: {e}. Returning dummy data')\n        idx = pd.date_range(start, end, freq='H', inclusive='left')\n        return pd.DataFrame({'load': 0.0}, index=idx)\n\n# MeteoSchweiz (Open Meteo) weather data\n\ndef fetch_weather(start: datetime, end: datetime, lat: float, lon: float) -> pd.DataFrame:\n    url = (\n        'https://api.open-meteo.com/v1/forecast'\n        f'?latitude={lat}&longitude={lon}&hourly=temperature_2m,wind_speed_10m'\n        f'&start_date={start.date()}&end_date={end.date()}&timezone=UTC'\n    )\n    try:\n        r = requests.get(url)\n        r.raise_for_status()\n        data = r.json()\n        times = pd.to_datetime(data['hourly']['time'])\n        df = pd.DataFrame({'temperature': data['hourly']['temperature_2m'],\n                           'wind_speed': data['hourly']['wind_speed_10m']},\n                          index=times)\n        return df\n    except Exception as e:\n        print(f'Could not download weather data: {e}. Returning dummy data')\n        idx = pd.date_range(start, end, freq='H', inclusive='left')\n        return pd.DataFrame({'temperature': 0.0, 'wind_speed': 0.0}, index=idx)\n\n# Swiss holidays\n\ndef fetch_holidays(start: datetime, end: datetime) -> pd.DataFrame:\n    if holidays is None:\n        raise RuntimeError('holidays library not installed')\n    ch_holidays = holidays.CH(years=range(start.year, end.year + 1))\n    idx = pd.date_range(start, end, freq='D')\n    flags = [1 if day.date() in ch_holidays else 0 for day in idx]\n    return pd.DataFrame({'holiday': flags}, index=idx)\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "\nstart = prices.index.min()\nend = prices.index.max() + pd.Timedelta(hours=1)\n\ntoken = os.getenv('ENTSOE_TOKEN', '')\nif token:\n    load = fetch_entsoe_load(start, end, token)\nelse:\n    print('ENTSOE_TOKEN not set. Using dummy load data')\n    load = fetch_entsoe_load(start, end, token)\n\nweather = fetch_weather(start, end, lat=46.8, lon=8.3)\nholidays_df = fetch_holidays(start, end)\n\n# Zusammenf\u00fchren auf Stundenbasis\nprices_h = prices.resample('H').mean()\ndata = prices_h.join(load, how='left').join(weather, how='left')\ndata = data.join(holidays_df, how='left')\ndata.head()\n"
+  },
+  {
+   "cell_type": "markdown",
    "id": "274da372",
    "metadata": {},
    "source": [


### PR DESCRIPTION
## Summary
- integrate functions from `fetch_additional_data.py` into the notebook
- show how to merge ENTSO-E, weather and holiday data
- clarify README about the integrated data sources

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852d145d5bc8320816c7d53639cec3d